### PR TITLE
Added TweetedTimes bot

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -236,6 +236,7 @@ class CrawlerDetect
         'netresearchserver',
         'NetSeer Crawler',
         'NewsGator',
+        'newsme',
         'NextGenSearchBot',
         'NG-Search',
         'ngbot',

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -354,6 +354,7 @@ class CrawlerDetect
         'truwoGPS',
         'turnitinbot',
         'TweetedTimes Bot',
+        'tweetedtimes.com',
         'TweetmemeBot',
         'twengabot',
         'Twikle',

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -280,6 +280,7 @@ class CrawlerDetect
         'psbot',
         'purebot',
         'PycURL',
+        'Python-httplib2',
         'python-requests',
         'Python-urllib',
         'Qseero',

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -734,3 +734,4 @@ Ruby
 Mozilla/5.0 (compatible; BuzzSumo; +http://www.buzzsumo.com/bot.html)
 EventMachine HttpClient
 Mozilla/5.0 (compatible; +http://tweetedtimes.com)
+Python-httplib2/0.7.4 (gzip)

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -735,3 +735,4 @@ Mozilla/5.0 (compatible; BuzzSumo; +http://www.buzzsumo.com/bot.html)
 EventMachine HttpClient
 Mozilla/5.0 (compatible; +http://tweetedtimes.com)
 Python-httplib2/0.7.4 (gzip)
+newsme/1.0; feedback@news.me

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -733,3 +733,4 @@ AHC/1.0
 Ruby
 Mozilla/5.0 (compatible; BuzzSumo; +http://www.buzzsumo.com/bot.html)
 EventMachine HttpClient
+Mozilla/5.0 (compatible; +http://tweetedtimes.com)


### PR DESCRIPTION
Hi,

Here is a new bot I saw.

It is a best practice for "good crawlers" to have as User-Agent such as `Mozilla/5.0 (compatible; +http://tweetedtimes.com)`. No legitimate user will ever have an URL in its UA - maybe we could add `http:` to the generic regex?
