### PR TITLE
Added www.uptimedoctor.com to crawlers

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -557,6 +557,7 @@ class Crawlers extends AbstractProvider
         'zgrab',
         'ZnajdzFoto',
         'ZyBorg',
+        'www.uptimedoctor.com',
         '[a-z0-9\-_]*((?<!cu)bot|crawler|archiver|transcoder|spider)',
     );
 }

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -1544,3 +1544,4 @@ Zemanta Aggregator/0.9 +http://www.zemanta.com
 Zend_Http_Client
 ZnajdzFoto/Image 2.0
 zspider/0.9-dev http://feedback.redkolibri.com/
+www.uptimedoctor.com


### PR DESCRIPTION
uptimedoctor is a service that monitor websites uptime. It hits the server once in a while and should be classified as a potential crawler