### PR TITLE
add a check in getMatches that prevents an "Undefined index" error

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -178,6 +178,6 @@ class CrawlerDetect
      */
     public function getMatches()
     {
-        return $this->matches[0];
+        return count($this->matches[0] > 0) ? $this->matches[0] : null;
     }
 }


### PR DESCRIPTION
when getMatches is called on a not-crawler user agent