### PR TITLE
Add the Google-Youtube-Links bot

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -271,6 +271,7 @@ class Crawlers extends AbstractProvider
         'Google-SearchByImage',
         'Google-Site-Verification',
         'Google-Structured-Data-Testing-Tool',
+        'Google-Youtube-Links',
         'google_partner_monitoring',
         'GoogleDocs',
         'GoogleHC\/',

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -3064,3 +3064,4 @@ Jeffrey's Exif Viewer (http://regex.info/exif)
 Untiny
 Mozilla/5.0 (Grabify.link - https://grabify.link/expander)
 biNu image cacher (info@binu-inc.com)
+Mozilla/5.0 (compatible; Google-Youtube-Links)


### PR DESCRIPTION
Saw this one in my log and it wasn't recognizing it as a bot.