### PR TITLE
Add Jobg8 URL Monitor

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -383,6 +383,7 @@ class Crawlers extends AbstractProvider
         'Jaunt\/',
         'Jigsaw',
         'Jobboerse',
+        'Jobg8 URL Monitor',
         'jobo',
         'Jobrapido',
         'JS-Kit',

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -3157,3 +3157,4 @@ Mozilla/5.0 (compatible; historious/2.0; +http://historio.us/)
 Mozilla/5.0 (compatible; uCrawlr/1.0 ; +https://blog.ucoz.ru/upolicy)
 Mozilla/5.0 (compatible; Let's Encrypt validation server; +https://www.letsencrypt.org)
 Brodie/1.0 (+http://www.15miles.com/)
+Jobg8 URL Monitor


### PR DESCRIPTION
The "Jobg8 URL Monitor" user agent acts like a non-human for our site by not executing JavaScript and requesting from one IP address.