### PR TITLE
Feature: Extend Crawlers data array

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -93,7 +93,7 @@ class CrawlerDetect
      * Compile the regex patterns into one regex string.
      *
      * @param array
-     * 
+     *
      * @return string
      */
     public function compileRegex($patterns)
@@ -189,5 +189,19 @@ class CrawlerDetect
     public function getMatches()
     {
         return isset($this->matches[0]) ? $this->matches[0] : null;
+    }
+
+    /**
+     * Extend crawlers list.
+     *
+     * @param string|array $crawlers
+     */
+    public function extendCrawlers($crawlers)
+    {
+        if (is_string($crawlers)) {
+            $crawlers = [$crawlers];
+        }
+        $this->crawlers->extend($crawlers);
+        $this->compiledRegex = $this->compileRegex($this->crawlers->getAll());
     }
 }

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -199,7 +199,7 @@ class CrawlerDetect
     public function extendCrawlers($crawlers)
     {
         if (is_string($crawlers)) {
-            $crawlers = [$crawlers];
+            $crawlers = array($crawlers);
         }
         $this->crawlers->extend($crawlers);
         $this->compiledRegex = $this->compileRegex($this->crawlers->getAll());

--- a/src/Fixtures/AbstractProvider.php
+++ b/src/Fixtures/AbstractProvider.php
@@ -15,18 +15,30 @@ abstract class AbstractProvider
 {
     /**
      * The data set.
-     * 
+     *
      * @var array
      */
     protected $data;
 
     /**
      * Return the data set.
-     * 
+     *
      * @return array
      */
     public function getAll()
     {
         return $this->data;
+    }
+
+    /**
+     * Extend the data set.
+     *
+     * @param array $data
+     */
+    public function extend($data)
+    {
+        if (is_array($data) && count($data)) {
+            $this->data = array_merge($this->data, $data);
+        }
     }
 }

--- a/tests/UATests.php
+++ b/tests/UATests.php
@@ -124,4 +124,41 @@ class UserAgentTest extends TestCase
             }
         }
     }
+
+    /** @test */
+    public function extends_crawlers()
+    {
+        $crawlers = new Crawlers();
+
+        $crawlersCount = count($crawlers->getAll());
+        $newUserAgents = [
+            'some_user_agent',
+            'some_other_user_agent'
+        ];
+
+        $crawlers->extend($newUserAgents);
+
+        $this->assertNotEquals($crawlersCount, count($crawlers->getAll()));
+        $this->assertEquals($crawlersCount + count($newUserAgents), count($crawlers->getAll()));
+    }
+
+    /** @test */
+    public function extends_crawlers_as_string()
+    {
+        $cd = new CrawlerDetect(null, 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; some_user_agent)');
+        $this->assertFalse($cd->isCrawler());
+
+        $cd->extendCrawlers('some_user_agent');
+        $this->assertTrue($cd->isCrawler());
+    }
+
+    /** @test */
+    public function extends_crawlers_as_array()
+    {
+        $cd = new CrawlerDetect(null, 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; some_other_user_agent)');
+        $this->assertFalse($cd->isCrawler());
+
+        $cd->extendCrawlers(['some_user_agent', 'some_other_user_agent']);
+        $this->assertTrue($cd->isCrawler());
+    }
 }

--- a/tests/UATests.php
+++ b/tests/UATests.php
@@ -133,7 +133,7 @@ class UserAgentTest extends TestCase
         $crawlersCount = count($crawlers->getAll());
         $newUserAgents = array(
             'some_user_agent',
-            'some_other_user_agent'
+            'some_other_user_agent',
         );
 
         $crawlers->extend($newUserAgents);

--- a/tests/UATests.php
+++ b/tests/UATests.php
@@ -131,10 +131,10 @@ class UserAgentTest extends TestCase
         $crawlers = new Crawlers();
 
         $crawlersCount = count($crawlers->getAll());
-        $newUserAgents = [
+        $newUserAgents = array(
             'some_user_agent',
             'some_other_user_agent'
-        ];
+        );
 
         $crawlers->extend($newUserAgents);
 
@@ -158,7 +158,7 @@ class UserAgentTest extends TestCase
         $cd = new CrawlerDetect(null, 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; some_other_user_agent)');
         $this->assertFalse($cd->isCrawler());
 
-        $cd->extendCrawlers(['some_user_agent', 'some_other_user_agent']);
+        $cd->extendCrawlers(array('some_user_agent', 'some_other_user_agent'));
         $this->assertTrue($cd->isCrawler());
     }
 }


### PR DESCRIPTION
Hello and thanks for this great package!

### Introduction

The purpose of this PR is to allow the Crawlers data array to be extended with custom ones.
I understand that to add new Crawlers to the list and contribute to the community it's better to create a PR to this repo with the new user agent strings, but sometime (or while a PR to add a specific user agent) it would be faster just to extend the data array to allow custom user agents to be recognised as crawlers without adding a custom implementation.

### Description of changes

A new function has been added to the [AbstractProvider](https://github.com/JayBizzle/Crawler-Detect/compare/master...peppeocchi:feature-extend-crawlers?expand=1#diff-64808a9ec9bd18df26a4534d14064ddcR38) that allows to extends the data array with custom strings. I've added it to the abstract provider so it could be used by the other classes extending it (both `Exclusions` and `Headers`), although I haven't provided an implementation to CrawlerDetect for any other class except `Crawlers`.

### Example usage

The usage it's very simple, you can either pass a string or an array of strings, that would then be merged to the main data array, and the regex would compile again from the new list.

```php
$cd = new CrawlerDetect(/*some user agent string*/);

$cd->extendCrawlers('some_user_agent');

$cd->extendCrawlers([
    'some_user_agent_1',
    'some_user_agent_2',
    # more user agents....
]);
```

### Conclusions
Please feel free to make any change you might want to make before merging it, I would really love a feature like this to be built in the package rather than create my custom implementation just to add a couple of user agents to be detected as crawlers - or as I mentioned, it would be very useful while a PR waits to be merged with new user agents (e.g. https://github.com/JayBizzle/Crawler-Detect/pull/327)

Thanks!