### PR TITLE
Add DHSH as Crawler

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -271,6 +271,7 @@ class Crawlers extends AbstractProvider
         'DeuSu',
         'developers\.google\.com\/\+\/web\/snippet\/',
         'Devil',
+        'DHSH',
         'Digg',
         'Digincore',
         'DigitalPebble',


### PR DESCRIPTION
DHSH is a Service like bit.ly to short domains and create a statistic