### PR TITLE
Fixed StyleCI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,4 @@
+risky: true
 preset: none
 enabled:
  - array_element_white_space_after_comma


### PR DESCRIPTION
Risky mode needs to be enabled to use some of the fixers.