### PR TITLE
Replaced implicit type coercion with strict type check

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -93,7 +93,7 @@ class CrawlerDetect
      * Compile the regex patterns into one regex string.
      *
      * @param array
-     * 
+     *
      * @return string
      */
     public function compileRegex($patterns)
@@ -168,7 +168,7 @@ class CrawlerDetect
             $userAgent ?: $this->userAgent
         ));
 
-        if ($agent == '') {
+        if ($agent === '') {
             return false;
         }
 


### PR DESCRIPTION
By comparing `$agent` to the empty strict with loose equivalence (`==`) instead of strict equality (`===`), this permits matching more than just the empty string, according to the [PHP type comparison truth table](https://www.php.net/manual/en/types.comparisons.php#types.comparisions-loose). Specifically, `$agent` will also match if it contains the string `"0"`, rather than being empty, which I believe should be regarded as a false positive.