### PR TITLE
Simplified regex match storing code

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -172,13 +172,7 @@ class CrawlerDetect
             return false;
         }
 
-        $result = preg_match("/{$this->compiledRegex}/i", $agent, $matches);
-
-        if ($matches) {
-            $this->matches = $matches;
-        }
-
-        return (bool) $result;
+        return (bool) preg_match("/{$this->compiledRegex}/i", $agent, $this->matches);
     }
 
     /**


### PR DESCRIPTION
Rather than first writing matches to a temporary variable, we write them directly to the class member variable. This eliminates the temporary `$matches` variable and also the temporary `$result` variable.

Note that we also eliminated the `if` statement which is intentional because it is this author's belief that it is incorrect for two reasons:

1. It should not be conditional whether `$matches` are saved; if the method is called then `$matches` should always be updated rather than persist the result from a previous call.
2. As an aside, and although not addressed by this PR, it is this author's strong belief that _storing transient data_, such as regex matches, between method calls is an anti-pattern because it is not concurrency-safe. Such runtime information should be returned immediately by the method. However, this refactoring is left for future work and affects the entire class design, not just this method.