### PR TITLE
Fixed user agent type annotations.

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -20,9 +20,9 @@ class CrawlerDetect
     /**
      * The user agent.
      *
-     * @var null
+     * @var string|null
      */
-    protected $userAgent = null;
+    protected $userAgent;
 
     /**
      * Headers that contain a user agent.
@@ -138,7 +138,7 @@ class CrawlerDetect
     /**
      * Set the user agent.
      *
-     * @param string $userAgent
+     * @param string|null $userAgent
      */
     public function setUserAgent($userAgent)
     {


### PR DESCRIPTION
It seems pretty clear that the type of `CrawlerDetect::userAgent` is `string|null` throughout this file. However, in some places it is typed as just `null` and in others it is typed as just `string`, when in fact, both are possible in all contexts. Moreover, the type initialization to `null` is redundant because all fields are null by default.