### PR TITLE
Reduced imported FQCN names to imported leaf names

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -41,21 +41,21 @@ class CrawlerDetect
     /**
      * Crawlers object.
      *
-     * @var \Jaybizzle\CrawlerDetect\Fixtures\Crawlers
+     * @var Crawlers
      */
     protected $crawlers;
 
     /**
      * Exclusions object.
      *
-     * @var \Jaybizzle\CrawlerDetect\Fixtures\Exclusions
+     * @var Exclusions
      */
     protected $exclusions;
 
     /**
      * Headers object.
      *
-     * @var \Jaybizzle\CrawlerDetect\Fixtures\Headers
+     * @var Headers
      */
     protected $uaHttpHeaders;
 


### PR DESCRIPTION
It is not necessary to use the fully qualified class name (FQCN) in docblocks when the name is imported at the top of the file. They can be simplified to just the leaf name as they can in code.