### PR TITLE
Fixed outbrain regex

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -19,7 +19,6 @@ class Crawlers extends AbstractProvider
      * @var array
      */
     protected $data = array(
-        '.*Java.*outbrain',
         ' YLT',
         '^b0t$',
         '^bluefish ',
@@ -586,6 +585,7 @@ class Crawlers extends AbstractProvider
         'JAHHO',
         'janforman',
         'Jaunt\/',
+        'Java.*outbrain',
         'javelin\.io',
         'Jbrofuzz',
         'Jersey\/',

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -3879,3 +3879,4 @@ Mozilla/5.0 (compatible; Javelin; +https://about.javelin.io/)
 Amazon CloudFront
 swcd (unknown version) CFNetwork/1125.2 Darwin/19.4.0
 YahooMailProxy; https://help.yahoo.com/kb/yahoo-mail-proxy-SLN28749.html
+Mozilla/5.0 (Java) outbrain


### PR DESCRIPTION
Considering all regex patterns are non-anchored, there is no reason to prefix any pattern with `.*`. Fortunately there is only one such pattern with this prefix.