### PR TITLE
Drop support for EOL PHP versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.0, 7.1, 7.2, 7.3, 7.4]
+        php: [7.1, 7.2, 7.3, 7.4]
 
     name: PHP:${{ matrix.php }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches:
-      - "master"
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
+        php: [7.0, 7.1, 7.2, 7.3, 7.4]
 
     name: PHP:${{ matrix.php }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4]
 
     name: PHP:${{ matrix.php }}
 

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,7 +12,7 @@ $finder = Symfony\Component\Finder\Finder::create()
 return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
-        'array_syntax' => ['syntax' => 'long'],
+        'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => ['sortAlgorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^7.0|^8.5",
         "php-coveralls/php-coveralls": "1.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.5|^6.5",
+        "phpunit/phpunit": "^8.5",
         "php-coveralls/php-coveralls": "1.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0|^8.5",
+        "phpunit/phpunit": "^6.0|^7.0|^8.5",
         "php-coveralls/php-coveralls": "1.*"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          verbose="true"
          beStrictAboutOutputDuringTests="true"
 >

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -29,14 +29,14 @@ class CrawlerDetect
      *
      * @var array
      */
-    protected $httpHeaders = array();
+    protected $httpHeaders = [];
 
     /**
      * Store regex matches.
      *
      * @var array
      */
-    protected $matches = array();
+    protected $matches = [];
 
     /**
      * Crawlers object.
@@ -114,7 +114,7 @@ class CrawlerDetect
         }
 
         // Clear existing headers.
-        $this->httpHeaders = array();
+        $this->httpHeaders = [];
 
         // Only save HTTP headers. In PHP land, that means
         // only _SERVER vars that start with HTTP_.

--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -18,7 +18,7 @@ class Crawlers extends AbstractProvider
      *
      * @var array
      */
-    protected $data = array(
+    protected $data = [
         ' YLT',
         '^b0t$',
         '^bluefish ',
@@ -1357,5 +1357,5 @@ class Crawlers extends AbstractProvider
         'ZoteroTranslationServer',
         'ZyBorg',
         '[a-z0-9\-_]*(bot|crawl|archiver|transcoder|spider|uptime|validator|fetcher|cron|checker|reader|extractor|monitoring|analyzer|scraper)',
-    );
+    ];
 }

--- a/src/Fixtures/Exclusions.php
+++ b/src/Fixtures/Exclusions.php
@@ -19,7 +19,7 @@ class Exclusions extends AbstractProvider
      *
      * @var array
      */
-    protected $data = array(
+    protected $data = [
         'Safari.[\d\.]*',
         'Firefox.[\d\.]*',
         ' Chrome.[\d\.]*',
@@ -68,5 +68,5 @@ class Exclusions extends AbstractProvider
         '; ID bot',
         '; POWER BOT',
         ';', // Remove the following characters ;
-    );
+    ];
 }

--- a/src/Fixtures/Headers.php
+++ b/src/Fixtures/Headers.php
@@ -18,7 +18,7 @@ class Headers extends AbstractProvider
      *
      * @var array
      */
-    protected $data = array(
+    protected $data = [
         // The default User-Agent string.
         'HTTP_USER_AGENT',
         // Header can occur on devices using Opera Mini.
@@ -33,5 +33,5 @@ class Headers extends AbstractProvider
         // Sometimes, bots (especially Google) use a genuine user agent, but fill this header in with their email address
         'HTTP_FROM',
         'HTTP_X_SCANNER', // Seen in use by Netsparker
-    );
+    ];
 }

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -47,7 +47,7 @@ final class UserAgentTest extends TestCase
     /** @test */
     public function it_returns_correct_matched_bot_name()
     {
-        $test = $this->CrawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
+        $this->CrawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
 
         $matches = $this->CrawlerDetect->getMatches();
 
@@ -57,11 +57,11 @@ final class UserAgentTest extends TestCase
     /** @test */
     public function it_returns_null_when_no_bot_detected()
     {
-        $test = $this->CrawlerDetect->isCrawler('nothing to see here');
+        $this->CrawlerDetect->isCrawler('nothing to see here');
 
-        $matches = $this->CrawlerDetect->getMatches();
+        $this->CrawlerDetect->getMatches();
 
-        $this->assertEquals($this->CrawlerDetect->getMatches(), null, $matches);
+        $this->assertEquals($this->CrawlerDetect->getMatches(), null);
     }
 
     /** @test */

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -17,7 +17,7 @@ final class UserAgentTest extends TestCase
 {
     private $CrawlerDetect;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->CrawlerDetect = new CrawlerDetect();
     }


### PR DESCRIPTION
This is not a firm decision, just exploring the possibility only supporting officially supported PHP versions - https://www.php.net/supported-versions.php