### PR TITLE
Add frontman crawler to list

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -426,6 +426,7 @@ class Crawlers extends AbstractProvider
         'free thumbnails',
         'Freeuploader',
         'FreshRSS',
+        'frontman',
         'Funnelback',
         'Fuzz Faster U Fool',
         'G-i-g-a-b-o-t',

--- a/tests/crawlers.txt
+++ b/tests/crawlers.txt
@@ -3652,3 +3652,4 @@ awin.com - site screen shotter
 chatterino-api-cache/1.0 link-resolver
 gobuster/3.1.0
 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.114 Safari/537.36 DatadogSynthetics
+frontman


### PR DESCRIPTION
Based on #487, I've added the frontman crawler to the list.

According to https://github.com/cloudradar/frontman, they use `frontman` as user agent.