### PR TITLE
Better detecting of all `headless` browsers

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -534,7 +534,6 @@ class Crawlers extends AbstractProvider
         'Hatena',
         'Havij',
         'HaxerMen',
-        'HeadlessChrome',
         'HEADMasterSEO',
         'HeartRails_Capture',
         'help@dataminr\.com',
@@ -1435,6 +1434,6 @@ class Crawlers extends AbstractProvider
         'Zoom\.Mac',
         'ZoteroTranslationServer',
         'ZyBorg',
-        '[a-z0-9\-_]*(bot|crawl|archiver|transcoder|spider|uptime|validator|fetcher|cron|checker|reader|extractor|monitoring|analyzer|scraper)',
+        '[a-z0-9\-_]*(bot|crawl|headless|archiver|transcoder|spider|uptime|validator|fetcher|cron|checker|reader|extractor|monitoring|analyzer|scraper)',
     ];
 }

--- a/tests/data/user_agent/crawlers.txt
+++ b/tests/data/user_agent/crawlers.txt
@@ -6,6 +6,7 @@ CheckHost (http://check-host.net/)
 YandeG 1.03
 yacybot (/global; amd64 Linux 3.16-0.bpo.2-amd64; java 1.7.0_65; Europe/en) http://yacy.net/bot.html
 SEMrushBot
+Headless Chrome 131.0.6778.87 on GNU/Linux
 Protopage/3.0 (http://www.protopage.com)
 yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_75; Europe/en) http://yacy.net/bot.html
 StatoolsBot (+http://www.statools.com/bot.html)

--- a/tests/data/user_agent/crawlers.txt
+++ b/tests/data/user_agent/crawlers.txt
@@ -6,8 +6,6 @@ CheckHost (http://check-host.net/)
 YandeG 1.03
 yacybot (/global; amd64 Linux 3.16-0.bpo.2-amd64; java 1.7.0_65; Europe/en) http://yacy.net/bot.html
 SEMrushBot
-AdsBot-Google (+http://www.google.com/adsbot.html)
-Google-Adwords-Instant (+http://www.google.com/adsbot.html)
 Headless Chrome 131.0.6778.87 on GNU/Linux
 Protopage/3.0 (http://www.protopage.com)
 yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_75; Europe/en) http://yacy.net/bot.html

--- a/tests/data/user_agent/crawlers.txt
+++ b/tests/data/user_agent/crawlers.txt
@@ -6,6 +6,8 @@ CheckHost (http://check-host.net/)
 YandeG 1.03
 yacybot (/global; amd64 Linux 3.16-0.bpo.2-amd64; java 1.7.0_65; Europe/en) http://yacy.net/bot.html
 SEMrushBot
+AdsBot-Google (+http://www.google.com/adsbot.html)
+Google-Adwords-Instant (+http://www.google.com/adsbot.html)
 Headless Chrome 131.0.6778.87 on GNU/Linux
 Protopage/3.0 (http://www.protopage.com)
 yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_75; Europe/en) http://yacy.net/bot.html


### PR DESCRIPTION
Added `headless` as a general term to look at, since all headless browsers can (probably quite safely?) be described as crawlers. So then also removed the `HeadlessChrome` check specifically to avoid collisions.

Closes #556 