### PR TITLE
Added Mailpit Detection

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -737,7 +737,7 @@ class Crawlers extends AbstractProvider
         'Mail::STS',
         'MailChimp',
         'Mail\.Ru',
-        'Mailpit',
+        'Mailpit\/',
         'Majestic12',
         'makecontact\/',
         'Mandrill',

--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -737,6 +737,7 @@ class Crawlers extends AbstractProvider
         'Mail::STS',
         'MailChimp',
         'Mail\.Ru',
+        'Mailpit',
         'Majestic12',
         'makecontact\/',
         'Mandrill',

--- a/tests/data/user_agent/crawlers.txt
+++ b/tests/data/user_agent/crawlers.txt
@@ -3683,3 +3683,4 @@ symbolicator/24.11.1
 symbolicator/24.12.1
 Barracuda Sentinel (EE)
 Mozilla/5.0(compatible;MatchorySearch/1.3;+https://www.matchory.com)
+Mailpit/v1.23.1


### PR DESCRIPTION
https://mailpit.axllent.org

Mailpit crawls the links inside email content to check for errors.
This behavior results in unexpected page views during local development.