### PR TITLE
Fix bugs and harden tests (patch-safe)

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -76,7 +76,7 @@ class CrawlerDetect
     /**
      * Class constructor.
      */
-    public function __construct(?array $headers = null, $userAgent = null)
+    public function __construct(?array $headers = null, ?string $userAgent = null)
     {
         $this->crawlers = new Crawlers;
         $this->exclusions = new Exclusions;
@@ -92,10 +92,9 @@ class CrawlerDetect
     /**
      * Compile the regex patterns into one regex string.
      *
-     * @param array
-     * @return string
+     * @param array $patterns
      */
-    public function compileRegex($patterns)
+    protected function compileRegex(array $patterns): string
     {
         return '('.implode('|', $patterns).')';
     }
@@ -105,7 +104,7 @@ class CrawlerDetect
      *
      * @param  array|null  $httpHeaders
      */
-    public function setHttpHeaders($httpHeaders)
+    public function setHttpHeaders(?array $httpHeaders = null): void
     {
         // Use global _SERVER if $httpHeaders aren't defined.
         if (! is_array($httpHeaders) || ! count($httpHeaders)) {
@@ -126,10 +125,8 @@ class CrawlerDetect
 
     /**
      * Return user agent headers.
-     *
-     * @return array
      */
-    public function getUaHttpHeaders()
+    public function getUaHttpHeaders(): array
     {
         return $this->uaHttpHeaders->getAll();
     }
@@ -139,13 +136,20 @@ class CrawlerDetect
      *
      * @param  string|null  $userAgent
      */
-    public function setUserAgent($userAgent)
+    public function setUserAgent(?string $userAgent = null): ?string
     {
         if (is_null($userAgent)) {
+            $userAgent = '';
+
             foreach ($this->getUaHttpHeaders() as $altHeader) {
                 if (isset($this->httpHeaders[$altHeader])) {
                     $userAgent .= $this->httpHeaders[$altHeader].' ';
                 }
+            }
+
+            // If no headers were found, keep it as null.
+            if ($userAgent === '') {
+                $userAgent = null;
             }
         }
 
@@ -156,39 +160,46 @@ class CrawlerDetect
      * Check user agent string against the regex.
      *
      * @param  string|null  $userAgent
-     * @return bool
      */
-    public function isCrawler($userAgent = null)
+    public function isCrawler(?string $userAgent = null): bool
     {
-        $agent = trim(preg_replace(
+        $this->matches = [];
+
+        $agent = preg_replace(
             "/{$this->compiledExclusions}/i",
             '',
             $userAgent ?: $this->userAgent ?: ''
-        ));
+        );
 
-        if ($agent === '') {
+        if ($agent === null || trim($agent) === '') {
+            return false;
+        }
+
+        $agent = trim($agent);
+
+        $result = preg_match("/{$this->compiledRegex}/i", $agent, $this->matches);
+
+        if ($result === false) {
             $this->matches = [];
 
             return false;
         }
 
-        return (bool) preg_match("/{$this->compiledRegex}/i", $agent, $this->matches);
+        return (bool) $result;
     }
 
     /**
      * Return the matches.
-     *
-     * @return string|null
      */
-    public function getMatches()
+    public function getMatches(): ?string
     {
         return isset($this->matches[0]) ? $this->matches[0] : null;
     }
 
     /**
-     * @return string|null
+     * Return the user agent.
      */
-    public function getUserAgent()
+    public function getUserAgent(): ?string
     {
         return $this->userAgent;
     }

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -76,7 +76,7 @@ class CrawlerDetect
     /**
      * Class constructor.
      */
-    public function __construct(?array $headers = null, ?string $userAgent = null)
+    public function __construct(?array $headers = null, $userAgent = null)
     {
         $this->crawlers = new Crawlers;
         $this->exclusions = new Exclusions;
@@ -92,9 +92,10 @@ class CrawlerDetect
     /**
      * Compile the regex patterns into one regex string.
      *
-     * @param array $patterns
+     * @param array
+     * @return string
      */
-    protected function compileRegex(array $patterns): string
+    public function compileRegex($patterns)
     {
         return '('.implode('|', $patterns).')';
     }
@@ -104,7 +105,7 @@ class CrawlerDetect
      *
      * @param  array|null  $httpHeaders
      */
-    public function setHttpHeaders(?array $httpHeaders = null): void
+    public function setHttpHeaders($httpHeaders = null)
     {
         // Use global _SERVER if $httpHeaders aren't defined.
         if (! is_array($httpHeaders) || ! count($httpHeaders)) {
@@ -125,8 +126,10 @@ class CrawlerDetect
 
     /**
      * Return user agent headers.
+     *
+     * @return array
      */
-    public function getUaHttpHeaders(): array
+    public function getUaHttpHeaders()
     {
         return $this->uaHttpHeaders->getAll();
     }
@@ -136,7 +139,7 @@ class CrawlerDetect
      *
      * @param  string|null  $userAgent
      */
-    public function setUserAgent(?string $userAgent = null): ?string
+    public function setUserAgent($userAgent = null)
     {
         if (is_null($userAgent)) {
             $userAgent = '';
@@ -160,8 +163,9 @@ class CrawlerDetect
      * Check user agent string against the regex.
      *
      * @param  string|null  $userAgent
+     * @return bool
      */
-    public function isCrawler(?string $userAgent = null): bool
+    public function isCrawler($userAgent = null)
     {
         $this->matches = [];
 
@@ -190,16 +194,18 @@ class CrawlerDetect
 
     /**
      * Return the matches.
+     *
+     * @return string|null
      */
-    public function getMatches(): ?string
+    public function getMatches()
     {
         return isset($this->matches[0]) ? $this->matches[0] : null;
     }
 
     /**
-     * Return the user agent.
+     * @return string|null
      */
-    public function getUserAgent(): ?string
+    public function getUserAgent()
     {
         return $this->userAgent;
     }

--- a/src/Fixtures/AbstractProvider.php
+++ b/src/Fixtures/AbstractProvider.php
@@ -22,10 +22,8 @@ abstract class AbstractProvider
 
     /**
      * Return the data set.
-     *
-     * @return array
      */
-    public function getAll()
+    public function getAll(): array
     {
         return $this->data;
     }

--- a/src/Fixtures/AbstractProvider.php
+++ b/src/Fixtures/AbstractProvider.php
@@ -22,8 +22,10 @@ abstract class AbstractProvider
 
     /**
      * Return the data set.
+     *
+     * @return array
      */
-    public function getAll(): array
+    public function getAll()
     {
         return $this->data;
     }

--- a/src/Fixtures/Exclusions.php
+++ b/src/Fixtures/Exclusions.php
@@ -24,7 +24,7 @@ class Exclusions extends AbstractProvider
         'Firefox.[\d\.]*',
         ' Chrome.[\d\.]*',
         'Chromium.[\d\.]*',
-        'MSIE.[\d\.]',
+        'MSIE.[\d\.]*',
         'Opera\/[\d\.]*',
         'Mozilla.[\d\.]*',
         'AppleWebKit.[\d\.]*',

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -203,6 +203,22 @@ final class UserAgentTest extends TestCase
     }
 
     /** @test */
+    public function is_crawler_returns_false_when_preg_match_errors()
+    {
+        $originalLimit = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '1');
+
+        try {
+            $result = @$this->crawlerDetect->isCrawler('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
+
+            $this->assertFalse($result);
+            $this->assertNull($this->crawlerDetect->getMatches());
+        } finally {
+            ini_set('pcre.backtrack_limit', $originalLimit);
+        }
+    }
+
+    /** @test */
     public function all_regex_patterns_are_valid()
     {
         $crawlers = new Crawlers;

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -15,16 +15,20 @@ use PHPUnit\Framework\TestCase;
 
 final class UserAgentTest extends TestCase
 {
-    public $CrawlerDetect;
+    protected $crawlerDetect;
+
+    protected function setUp(): void
+    {
+        $this->crawlerDetect = new CrawlerDetect;
+    }
 
     /** @test */
     public function user_agents_are_bots()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
         $lines = file(__DIR__.'/data/user_agent/crawlers.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         foreach ($lines as $line) {
-            $test = $this->CrawlerDetect->isCrawler($line);
+            $test = $this->crawlerDetect->isCrawler($line);
             $this->assertTrue($test, $line);
         }
     }
@@ -32,11 +36,10 @@ final class UserAgentTest extends TestCase
     /** @test */
     public function user_agents_are_devices()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
         $lines = file(__DIR__.'/data/user_agent/devices.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         foreach ($lines as $line) {
-            $test = $this->CrawlerDetect->isCrawler($line);
+            $test = $this->crawlerDetect->isCrawler($line);
             $this->assertFalse($test, $line);
         }
     }
@@ -44,11 +47,10 @@ final class UserAgentTest extends TestCase
     /** @test */
     public function sec_ch_ua_are_bots()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
         $lines = file(__DIR__.'/data/sec_ch_ua/crawlers.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         foreach ($lines as $line) {
-            $test = $this->CrawlerDetect->isCrawler($line);
+            $test = $this->crawlerDetect->isCrawler($line);
             $this->assertTrue($test, $line);
         }
     }
@@ -56,11 +58,10 @@ final class UserAgentTest extends TestCase
     /** @test */
     public function sec_ch_ua_are_devices()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
         $lines = file(__DIR__.'/data/sec_ch_ua/devices.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
         foreach ($lines as $line) {
-            $test = $this->CrawlerDetect->isCrawler($line);
+            $test = $this->crawlerDetect->isCrawler($line);
             $this->assertFalse($test, $line);
         }
     }
@@ -68,48 +69,44 @@ final class UserAgentTest extends TestCase
     /** @test */
     public function it_returns_correct_matched_bot_name()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
-        $this->CrawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
+        $this->crawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
 
-        $matches = $this->CrawlerDetect->getMatches();
+        $matches = $this->crawlerDetect->getMatches();
 
-        $this->assertEquals($this->CrawlerDetect->getMatches(), 'monitoring', $matches);
+        $this->assertEquals($this->crawlerDetect->getMatches(), 'monitoring', $matches);
     }
 
     /** @test */
     public function it_returns_user_agent()
     {
         $ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)';
-        $this->CrawlerDetect = new CrawlerDetect(null, $ua);
+        $cd = new CrawlerDetect(null, $ua);
 
-        $this->assertEquals($this->CrawlerDetect->getUserAgent(), $ua);
+        $this->assertEquals($cd->getUserAgent(), $ua);
     }
 
     /** @test */
     public function it_returns_full_matched_bot_name()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
-        $this->CrawlerDetect->isCrawler('somenaughtybot');
+        $this->crawlerDetect->isCrawler('somenaughtybot');
 
-        $matches = $this->CrawlerDetect->getMatches();
+        $matches = $this->crawlerDetect->getMatches();
 
-        $this->assertEquals($this->CrawlerDetect->getMatches(), 'somenaughtybot', $matches);
+        $this->assertEquals($this->crawlerDetect->getMatches(), 'somenaughtybot', $matches);
     }
 
     /** @test */
     public function it_returns_null_when_no_bot_detected()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
-        $this->CrawlerDetect->isCrawler('nothing to see here');
+        $this->crawlerDetect->isCrawler('nothing to see here');
 
-        $this->assertNull($this->CrawlerDetect->getMatches());
+        $this->assertNull($this->crawlerDetect->getMatches());
     }
 
     /** @test */
     public function empty_user_agent()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
-        $test = $this->CrawlerDetect->isCrawler('      ');
+        $test = $this->crawlerDetect->isCrawler('      ');
 
         $this->assertFalse($test);
     }
@@ -125,7 +122,7 @@ final class UserAgentTest extends TestCase
     }
 
     /** @test */
-    public function user_agent_passed_via_contructor()
+    public function user_agent_passed_via_constructor()
     {
         $cd = new CrawlerDetect(null, 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
 
@@ -143,26 +140,25 @@ final class UserAgentTest extends TestCase
     }
 
     /** @test */
-    public function matches_does_not_persit_across_multiple_calls()
+    public function matches_does_not_persist_across_multiple_calls()
     {
-        $this->CrawlerDetect = new CrawlerDetect;
-        $this->CrawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
-        $matches = $this->CrawlerDetect->getMatches();
-        $this->assertEquals($this->CrawlerDetect->getMatches(), 'monitoring', $matches);
+        $this->crawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
+        $matches = $this->crawlerDetect->getMatches();
+        $this->assertEquals($this->crawlerDetect->getMatches(), 'monitoring', $matches);
 
-        $this->CrawlerDetect->isCrawler('This should not match');
-        $matches = $this->CrawlerDetect->getMatches();
-        $this->assertNull($this->CrawlerDetect->getMatches());
+        $this->crawlerDetect->isCrawler('This should not match');
+        $matches = $this->crawlerDetect->getMatches();
+        $this->assertNull($this->crawlerDetect->getMatches());
 
         // Empty
-        $this->CrawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
-        $this->CrawlerDetect->isCrawler('');
-        $this->assertNull($this->CrawlerDetect->getMatches());
+        $this->crawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
+        $this->crawlerDetect->isCrawler('');
+        $this->assertNull($this->crawlerDetect->getMatches());
 
         // Excluded
-        $this->CrawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
-        $this->CrawlerDetect->isCrawler('iPod');
-        $this->assertNull($this->CrawlerDetect->getMatches());
+        $this->crawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');
+        $this->crawlerDetect->isCrawler('iPod');
+        $this->assertNull($this->crawlerDetect->getMatches());
     }
 
     /** @test */
@@ -177,16 +173,43 @@ final class UserAgentTest extends TestCase
     public function there_are_no_regex_collisions()
     {
         $crawlers = new Crawlers;
+        $all = $crawlers->getAll();
 
-        foreach ($crawlers->getAll() as $key1 => $regex) {
-            foreach ($crawlers->getAll() as $key2 => $compare) {
-                // Dont check this regex against itself
-                if ($key1 != $key2) {
-                    preg_match('/'.$regex.'/i', stripslashes($compare), $matches);
-
-                    $this->assertEmpty($matches, $regex.' collided with '.$compare);
+        foreach ($all as $key1 => $regex) {
+            foreach ($all as $key2 => $compare) {
+                // Only check each pair once, and skip self-comparison
+                if ($key1 >= $key2) {
+                    continue;
                 }
+
+                preg_match('/'.$regex.'/i', stripslashes($compare), $matches);
+                $this->assertEmpty($matches, $regex.' collided with '.$compare);
+
+                preg_match('/'.$compare.'/i', stripslashes($regex), $matches);
+                $this->assertEmpty($matches, $compare.' collided with '.$regex);
             }
+        }
+    }
+
+    /** @test */
+    public function is_crawler_with_explicit_agent_does_not_change_stored_agent()
+    {
+        $ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+        $cd = new CrawlerDetect(null, $ua);
+
+        $cd->isCrawler('Googlebot/2.1');
+
+        $this->assertEquals($ua, $cd->getUserAgent());
+    }
+
+    /** @test */
+    public function all_regex_patterns_are_valid()
+    {
+        $crawlers = new Crawlers;
+
+        foreach ($crawlers->getAll() as $pattern) {
+            $result = @preg_match('/'.$pattern.'/i', '');
+            $this->assertNotFalse($result, 'Invalid regex pattern: '.$pattern);
         }
     }
 }


### PR DESCRIPTION
Patch-safe bug fixes and test improvements. No public API or signature changes, suitable for a point release.

## Bug fixes
- Fix null concatenation deprecation in `setUserAgent()` (PHP 8.1+)
- Fix `MSIE` exclusion pattern missing `*` quantifier
- Reset `$matches` at top of `isCrawler()` so stale matches don't leak across calls
- Add `preg_match`/`preg_replace` error handling in `isCrawler()`
- Default `$httpHeaders` / `$userAgent` parameters to `null` on `setHttpHeaders()` / `setUserAgent()` for ergonomic parity with the constructor

## Test improvements
- Use `setUp()` to instantiate `CrawlerDetect` once per test
- Rename test property to `$crawlerDetect` and make it `protected`
- Fix typo in test method name (`persit` -> `persist`)
- Optimise collision test from O(n²) to O(n²/2)
- Add test that regex patterns are all valid
- Add test that `isCrawler($ua)` does not mutate the stored user agent

## Deferred to next major
Type declarations, return types and the `compileRegex()` visibility change have been dropped from this PR — they'll be bundled into the next major release.