### PR TITLE
Drop unused capture group and memoize compiled regex

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -74,6 +74,15 @@ class CrawlerDetect
     protected $compiledExclusions;
 
     /**
+     * Cache of compiled regex strings keyed by pattern-list hash, shared
+     * across instances so per-request `new CrawlerDetect` calls don't
+     * re-implode the (~1500-entry) pattern list each time.
+     *
+     * @var array<string, string>
+     */
+    protected static $compileCache = [];
+
+    /**
      * Class constructor.
      */
     public function __construct(?array $headers = null, $userAgent = null)
@@ -92,12 +101,21 @@ class CrawlerDetect
     /**
      * Compile the regex patterns into one regex string.
      *
+     * A non-capturing group is used because callers only need the full
+     * match (preg_match's $matches[0]), not a back-reference.
+     *
      * @param array
      * @return string
      */
     public function compileRegex($patterns)
     {
-        return '('.implode('|', $patterns).')';
+        $key = md5(serialize($patterns));
+
+        if (! isset(self::$compileCache[$key])) {
+            self::$compileCache[$key] = '(?:'.implode('|', $patterns).')';
+        }
+
+        return self::$compileCache[$key];
     }
 
     /**


### PR DESCRIPTION
## Summary

Two small changes to `CrawlerDetect::compileRegex`:

- **Non-capturing group.** The combined pattern wraps the alternation in `(...)`, but `getMatches()` returns `$matches[0]` — the full match — so the capturing backreference is never read. Switched to `(?:...)` so PCRE doesn't allocate the group.
- **Process-wide compile cache.** A static array keyed by `md5(serialize($patterns))` skips the implode of the ~1500-entry crawler list on every `new CrawlerDetect`. Frameworks that instantiate per request (Laravel middleware, etc.) get the win without changing the public API.

No behavioural change — `getMatches()` still returns the full matched substring.

## Test plan

- [x] `vendor/bin/phpunit` — 19 tests, 2,274,786 assertions, all pass on PHP 8.4
- [ ] CI matrix (PHP 7.1 → 8.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)