### PR TITLE
Clean up CI: scoped coverage, bump coveralls and php-cs-fixer

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,14 +8,14 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     ref: ${{ github.head_ref }}
 
             -   name: Run PHP CS Fixer
-                uses: docker://oskarstark/php-cs-fixer-ga:2.18.6
+                uses: docker://oskarstark/php-cs-fixer-ga:3.26.0
                 with:
-                    args: --config=.php_cs.dist --allow-risky=yes
+                    args: --allow-risky=yes
 
             -   name: Commit changes
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer global require php-coveralls/php-coveralls "^2.7"
-          coveralls --coverage_clover=tests/logs/clover.xml -v
+          php-coveralls --coverage_clover=tests/logs/clover.xml -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
-          coverage: xdebug
+          coverage: ${{ matrix.php == '8.3' && 'xdebug' || 'none' }}
 
       - name: Get composer cache directory
         id: composer-cache
@@ -46,11 +46,12 @@ jobs:
 
       - name: Run Unit tests
         run: |
-          vendor/bin/phpunit --coverage-clover=tests/logs/clover.xml
+          vendor/bin/phpunit ${{ matrix.php == '8.3' && '--coverage-clover=tests/logs/clover.xml' || '' }}
 
       - name: Upload coverage results to Coveralls
+        if: matrix.php == '8.3'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer global require php-coveralls/php-coveralls "^1.0"
+          composer global require php-coveralls/php-coveralls "^2.7"
           coveralls --coverage_clover=tests/logs/clover.xml -v

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ composer.phar
 composer.lock
 .DS_Store
 .phpunit.result.cache
-.php_cs.cache
+.php-cs-fixer.cache
 .coveralls.yml export-ignore
 .php_cs.dist export-ignore
 phpunit.xml export-ignore

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-$finder = Symfony\Component\Finder\Finder::create()
+$finder = PhpCsFixer\Finder::create()
     ->in([
         __DIR__.'/src',
         __DIR__.'/tests',
@@ -9,13 +9,13 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR2' => true,
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,


### PR DESCRIPTION
## Summary

CI hygiene with no impact on detection behaviour:

- **Scoped coverage.** xdebug was installed on every matrix job (PHP 7.1 → 8.4), but only one upload is actually needed. Now only the PHP 8.3 job installs xdebug and runs phpunit with `--coverage-clover`. Everything else runs with `coverage: none`, which is meaningfully faster.
- **Bump php-coveralls.** `^1.0` is from 2018. Bumped to `^2.7`.
- **Bump PHP CS Fixer.** Image moved from `2.18.6` (unmaintained) to `3.26.0`. Required the config rewrite below.
- **Config migration to v3.** Renamed `.php_cs.dist` → `.php-cs-fixer.dist.php` (v3 canonical name, so the `--config` flag is no longer needed), switched `Config::create()` to `new Config()`, and renamed the two rules that v3 changed (`sortAlgorithm` → `sort_algorithm`, `trailing_comma_in_multiline_array` → `trailing_comma_in_multiline`).
- **Other small bits.** `actions/checkout@v3` → `@v4` in the cs-fixer workflow (aligns with `test.yml`); `.gitignore` updated to match v3's cache filename.

## Test plan

- [x] Local `vendor/bin/phpunit` still green (19 tests, 2,274,786 assertions)
- [x] `php -l .php-cs-fixer.dist.php` clean
- [ ] CI matrix passes on this branch
- [ ] PHP CS Fixer workflow runs cleanly against the new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)