### PR TITLE
Fix contributor instructions: correct test path, drop raw/ ask

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
 ### Contributing
-If you find a bot/spider/crawler user agent that CrawlerDetect fails to detect, please submit a pull request with 
-- regex pattern added to the `$data` array in `Fixtures/Crawlers.php` and to the raw files `raw/Crawlers.json` and `raw/Crawlers.txt`
-- add the failing user agent to `tests/crawlers.txt`.
+If you find a bot/spider/crawler user agent that CrawlerDetect fails to detect, please submit a pull request with
+- regex pattern added to the `$data` array in `src/Fixtures/Crawlers.php`
+- the failing user agent string added to `tests/data/user_agent/crawlers.txt`
+
+The `raw/Crawlers.json` and `raw/Crawlers.txt` files are regenerated automatically by `export.php` after each merge to `master` — you do not need to update them by hand.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ echo $CrawlerDetect->getMatches();
 
 If you find a bot, spider or crawler that CrawlerDetect fails to detect, please open a pull request that:
 
-- adds the regex pattern to the `$data` array in `src/Fixtures/Crawlers.php` and to the raw files `raw/Crawlers.json` and `raw/Crawlers.txt`
-- adds the failing user agent string to `tests/crawlers.txt`
+- adds the regex pattern to the `$data` array in `src/Fixtures/Crawlers.php`
+- adds the failing user agent string to `tests/data/user_agent/crawlers.txt`
+
+The `raw/Crawlers.json` and `raw/Crawlers.txt` files are regenerated automatically by `export.php` after merge — no need to touch them.
 
 If you're not able to submit a PR, open an issue with the user agent string and we'll take it from there.
 


### PR DESCRIPTION
## Summary

CONTRIBUTING.md and README.md tell contributors to add new user agent strings to `tests/crawlers.txt` — but the file actually lives at `tests/data/user_agent/crawlers.txt`. New contributors following the docs hit a missing path.

Also stopped asking contributors to update `raw/Crawlers.json` and `raw/Crawlers.txt` manually. The `Export after tests` workflow runs `export.php` on every successful merge to `master`, so anything a contributor puts in those files gets regenerated anyway.

## Test plan

- [x] Paths in the updated docs exist (`src/Fixtures/Crawlers.php`, `tests/data/user_agent/crawlers.txt`)
- [x] `export.php` regenerates `raw/Crawlers.{json,txt}` (confirmed in `.github/workflows/export-on-tests.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)