### PR TITLE
Flag Czech bot

### DIFF
--- a/src/Fixtures/Crawlers.php
+++ b/src/Fixtures/Crawlers.php
@@ -830,6 +830,7 @@ class Crawlers extends AbstractProvider
         'myseosnapshot',
         'nagios',
         'Najdi\.si',
+        'holubem\.eu',
         'Name Intelligence',
         'NameFo\.com',
         'Nameprotect',

--- a/tests/data/user_agent/crawlers.txt
+++ b/tests/data/user_agent/crawlers.txt
@@ -3716,3 +3716,5 @@ SeoLik.ru
 Swisscows Favicons
 undici
 Web Downloader/6.9
+Najdu (Vyhledavac sluzeb (obsah) najdu.s.holubem.eu)
+Najdu (Vyhledavac sluzeb (hlavicka) najdu.s.holubem.eu)


### PR DESCRIPTION
**Type:** False negative

**User-Agent:**
```
Najdu (Vyhledavac sluzeb (hlavicka) najdu.s.holubem.eu) 
Najdu (Vyhledavac sluzeb (obsah) najdu.s.holubem.eu)
```

**CrawlerDetect result:** Not detected as crawler

**Why I believe this is incorrect:**
This user agent is Czech for “service search engine.”

