### PR TITLE
Key compiled-regex cache by fixture class instead of pattern hash

### DIFF
--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -11,6 +11,7 @@
 
 namespace Jaybizzle\CrawlerDetect;
 
+use Jaybizzle\CrawlerDetect\Fixtures\AbstractProvider;
 use Jaybizzle\CrawlerDetect\Fixtures\Crawlers;
 use Jaybizzle\CrawlerDetect\Fixtures\Exclusions;
 use Jaybizzle\CrawlerDetect\Fixtures\Headers;
@@ -74,7 +75,7 @@ class CrawlerDetect
     protected $compiledExclusions;
 
     /**
-     * Cache of compiled regex strings keyed by pattern-list hash, shared
+     * Cache of compiled regex strings keyed by fixture class name, shared
      * across instances so per-request `new CrawlerDetect` calls don't
      * re-implode the (~1500-entry) pattern list each time.
      *
@@ -91,11 +92,30 @@ class CrawlerDetect
         $this->exclusions = new Exclusions;
         $this->uaHttpHeaders = new Headers;
 
-        $this->compiledRegex = $this->compileRegex($this->crawlers->getAll());
-        $this->compiledExclusions = $this->compileRegex($this->exclusions->getAll());
+        $this->compiledRegex = $this->compileFixtureRegex($this->crawlers);
+        $this->compiledExclusions = $this->compileFixtureRegex($this->exclusions);
 
         $this->setHttpHeaders($headers);
         $this->setUserAgent($userAgent);
+    }
+
+    /**
+     * Compile and memoize the regex for a fixture provider.
+     *
+     * The pattern list is a fixed class property, so the class name is a
+     * sufficient cache key — cheaper than hashing the patterns themselves.
+     *
+     * @return string
+     */
+    protected function compileFixtureRegex(AbstractProvider $fixture)
+    {
+        $class = get_class($fixture);
+
+        if (! isset(self::$compileCache[$class])) {
+            self::$compileCache[$class] = $this->compileRegex($fixture->getAll());
+        }
+
+        return self::$compileCache[$class];
     }
 
     /**
@@ -104,18 +124,12 @@ class CrawlerDetect
      * A non-capturing group is used because callers only need the full
      * match (preg_match's $matches[0]), not a back-reference.
      *
-     * @param array
+     * @param  array  $patterns
      * @return string
      */
     public function compileRegex($patterns)
     {
-        $key = md5(serialize($patterns));
-
-        if (! isset(self::$compileCache[$key])) {
-            self::$compileCache[$key] = '(?:'.implode('|', $patterns).')';
-        }
-
-        return self::$compileCache[$key];
+        return '(?:'.implode('|', $patterns).')';
     }
 
     /**


### PR DESCRIPTION
## Summary

The compiled-regex memoization added in c617d86 (#605) keys its cache with `md5(serialize($patterns))`. Profiling shows that computing this key costs **~100µs** per construction, while the `implode()` it avoids costs only **~14µs** — so the cache made every `new CrawlerDetect` ~7× slower than having no cache at all.

The pattern lists are fixed class properties, so the fixture class name is a sufficient cache key:

- `compileRegex()` is restored to a pure compile step (and its incomplete `@param` tag fixed)
- memoization moves to a new protected `compileFixtureRegex(AbstractProvider $fixture)` helper, keyed by `get_class()`

## Measurements (PHP 8.4, 1000 iterations)

| | per `new CrawlerDetect` |
|---|---|
| before | ~104µs (~100µs of it serialize+md5) |
| after | ~2.6µs |

## Testing

- `vendor/bin/phpunit` — 19 tests, 2,277,691 assertions, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)