### PR TITLE
Add PHPStan static analysis (level 5) with CI workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,32 @@
+name: Static Analysis
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-24.04
+    name: PHPStan
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # PHPStan is installed via setup-php rather than require-dev because
+      # it needs PHP >= 7.4, while the test matrix still installs dev
+      # dependencies on PHP 7.1.
+      - name: Setup PHP, with composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          tools: composer:v2, phpstan
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Run PHPStan
+        run: phpstan analyse --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .DS_Store
 .phpunit.result.cache
 .php-cs-fixer.cache
+phpstan.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+    level: 5
+
+    paths:
+        - src
+        - tests
+
+    # Analyse against the library's minimum supported PHP version so
+    # syntax/feature regressions against the 7.1 floor are caught.
+    phpVersion: 70100

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -11,6 +11,7 @@
 
 namespace Jaybizzle\CrawlerDetect;
 
+use Jaybizzle\CrawlerDetect\Fixtures\AbstractProvider;
 use Jaybizzle\CrawlerDetect\Fixtures\Crawlers;
 use Jaybizzle\CrawlerDetect\Fixtures\Exclusions;
 use Jaybizzle\CrawlerDetect\Fixtures\Headers;
@@ -74,7 +75,7 @@ class CrawlerDetect
     protected $compiledExclusions;
 
     /**
-     * Cache of compiled regex strings keyed by pattern-list hash, shared
+     * Cache of compiled regex strings keyed by fixture class name, shared
      * across instances so per-request `new CrawlerDetect` calls don't
      * re-implode the (~1500-entry) pattern list each time.
      *
@@ -91,11 +92,30 @@ class CrawlerDetect
         $this->exclusions = new Exclusions;
         $this->uaHttpHeaders = new Headers;
 
-        $this->compiledRegex = $this->compileRegex($this->crawlers->getAll());
-        $this->compiledExclusions = $this->compileRegex($this->exclusions->getAll());
+        $this->compiledRegex = $this->compileFixtureRegex($this->crawlers);
+        $this->compiledExclusions = $this->compileFixtureRegex($this->exclusions);
 
         $this->setHttpHeaders($headers);
         $this->setUserAgent($userAgent);
+    }
+
+    /**
+     * Compile and memoize the regex for a fixture provider.
+     *
+     * The pattern list is a fixed class property, so the class name is a
+     * sufficient cache key — cheaper than hashing the patterns themselves.
+     *
+     * @return string
+     */
+    protected function compileFixtureRegex(AbstractProvider $fixture)
+    {
+        $class = get_class($fixture);
+
+        if (! isset(self::$compileCache[$class])) {
+            self::$compileCache[$class] = $this->compileRegex($fixture->getAll());
+        }
+
+        return self::$compileCache[$class];
     }
 
     /**
@@ -104,18 +124,12 @@ class CrawlerDetect
      * A non-capturing group is used because callers only need the full
      * match (preg_match's $matches[0]), not a back-reference.
      *
-     * @param array
+     * @param  array  $patterns
      * @return string
      */
     public function compileRegex($patterns)
     {
-        $key = md5(serialize($patterns));
-
-        if (! isset(self::$compileCache[$key])) {
-            self::$compileCache[$key] = '(?:'.implode('|', $patterns).')';
-        }
-
-        return self::$compileCache[$key];
+        return '(?:'.implode('|', $patterns).')';
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds static analysis as a separate CI workflow:

- **`phpstan.neon.dist`** — level 5 over `src` and `tests`, with `phpVersion: 70100` so analysis checks compatibility against the library's PHP 7.1 floor (it would catch accidental use of newer syntax/functions).
- **`.github/workflows/static-analysis.yml`** — runs on push/PR. PHPStan is installed via setup-php's `tools:` rather than `require-dev`, because PHPStan 2.x requires PHP ≥ 7.4 and adding it to composer.json would break `composer install` on the PHP 7.1 test-matrix job.
- `phpstan.neon` (local override convention) added to .gitignore.

Level 5 is the highest level that passes without code changes — levels 6+ mainly demand native property types and iterable value types, which the PHP 7.1 floor constrains. Worth revisiting if the floor is ever raised.

## Note

⚠️ **Stacked on #610** — merge that first (this branch includes its commit, since the docblock fix there is required for PHPStan to pass). Once #610 is merged, this PR will show only the PHPStan changes.

## Testing

- `phpstan analyse --no-progress` — `[OK] No errors` (PHPStan 2.2.2, PHP 8.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)