### PR TITLE
Bump actions to Node 24-ready versions

### DIFF
--- a/.github/workflows/export-on-tests.yml
+++ b/.github/workflows/export-on-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -32,6 +32,6 @@ jobs:
       run: php export.php
 
     - name: Commit changes
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: "Run export.php — update exported data [skip ci]"

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,7 +8,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
                 with:
                     ref: ${{ github.head_ref }}
 
@@ -18,6 +18,6 @@ jobs:
                     args: --allow-risky=yes
 
             -   name: Commit changes
-                uses: stefanzweifel/git-auto-commit-action@v4
+                uses: stefanzweifel/git-auto-commit-action@v7
                 with:
                     commit_message: Fix styling

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # PHPStan is installed via setup-php rather than require-dev because
       # it needs PHP >= 7.4, while the test matrix still installs dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP, with composer
         uses: shivammathur/setup-php@v2
@@ -34,7 +34,7 @@ jobs:
         shell: bash
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
## Summary

GitHub [forces actions onto Node 24 starting June 16, 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (Node 20 removed from runners September 16). The post-merge Test run on master explicitly flagged `actions/checkout@v4` and `actions/cache@v4`.

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | The "Node 24, no other changes" release. Deliberately *not* v6 — it moves credential persistence to a separate file, and both auto-commit workflows (`php-cs-fixer`, `export-on-tests`) push using checkout-persisted credentials. |
| `actions/cache` | v4 | **v5** | Node 24 release. |
| `stefanzweifel/git-auto-commit-action` | v4 | **v7** | v4 runs **Node 16**, so it's also affected. Reviewed the v5/v6/v7 breaking changes: v5 = Node 20 only; v6 removed `create_branch`/`skip_checkout`/`skip_fetch` (v7 restored them); none are used here — both workflows only pass `commit_message`. v7 runs Node 24. |

`shivammathur/setup-php@v2` is left alone — actively maintained and already Node 24-ready.

## Testing

- Test matrix + PHPStan + cs-fixer run on this PR (exercising checkout/cache v5 directly)
- The `export-on-tests` workflow (git-auto-commit v7) only runs on master pushes — worth watching the first post-merge run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)