### PR TITLE
Normalise header names so non-SAPI sources work

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ if ($CrawlerDetect->isCrawler('Mozilla/5.0 (compatible; Sosospider/2.0; +http://
 echo $CrawlerDetect->getMatches();
 ```
 
+### Passing headers from a request object
+
+With no arguments, CrawlerDetect reads `$_SERVER`. If your headers come from somewhere else — a PSR-7 request, Symfony's `HeaderBag`, Swoole, or a Lambda event — pass them in directly. Both real header names (`User-Agent`) and PHP's SAPI names (`HTTP_USER_AGENT`) are understood, and values may be strings or arrays of strings.
+
+```php
+// PSR-7 (Slim, Mezzio, Laminas, League)
+$CrawlerDetect = new CrawlerDetect($request->getHeaders());
+
+// Symfony HttpFoundation
+$CrawlerDetect = new CrawlerDetect($request->headers->all());
+
+// Swoole
+$CrawlerDetect = new CrawlerDetect($request->header);
+
+if ($CrawlerDetect->isCrawler()) {
+    // ...
+}
+```
+
+Prefer this over `isCrawler($request->getHeaderLine('User-Agent'))`. Some crawlers — Googlebot in particular — send a genuine browser `User-Agent` and identify themselves in another header such as `From` or `Sec-CH-UA`. Passing the full set lets CrawlerDetect check all of them; passing a single string can only ever check one.
+
 ## Contributing
 
 If you find a bot, spider or crawler that CrawlerDetect fails to detect, please open a pull request that:

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -177,9 +177,16 @@ class CrawlerDetect
      */
     protected function normaliseHeaderName($key)
     {
-        $key = str_replace('-', '_', strtoupper((string) $key));
+        $key = strtoupper((string) $key);
 
-        return strpos($key, 'HTTP_') === 0 ? substr($key, 5) : $key;
+        // Strip the prefix before folding hyphens, so only a genuine
+        // underscore-separated SAPI key loses it. A real header named
+        // 'Http-User-Agent' must not be mistaken for the user agent.
+        if (strpos($key, 'HTTP_') === 0) {
+            $key = substr($key, 5);
+        }
+
+        return str_replace('-', '_', $key);
     }
 
     /**

--- a/src/CrawlerDetect.php
+++ b/src/CrawlerDetect.php
@@ -135,6 +135,11 @@ class CrawlerDetect
     /**
      * Set HTTP headers.
      *
+     * Accepts either the _SERVER-style names PHP's SAPI produces
+     * (HTTP_USER_AGENT) or the real header names carried by a PSR-7 request,
+     * HttpFoundation, Swoole or a Lambda event ('User-Agent'). Both are stored
+     * under the canonical HTTP_ form so lookups stay uniform.
+     *
      * @param  array|null  $httpHeaders
      */
     public function setHttpHeaders($httpHeaders = null)
@@ -147,13 +152,46 @@ class CrawlerDetect
         // Clear existing headers.
         $this->httpHeaders = [];
 
-        // Only save HTTP headers. In PHP land, that means
-        // only _SERVER vars that start with HTTP_.
+        $uaHeaders = array_flip(
+            array_map([$this, 'normaliseHeaderName'], $this->getUaHttpHeaders())
+        );
+
+        // Only save HTTP headers. In PHP land, that means _SERVER vars that
+        // start with HTTP_ — plus, for non-SAPI sources, any key whose real
+        // header name is one we actually read.
         foreach ($httpHeaders as $key => $value) {
-            if (strpos($key, 'HTTP_') === 0) {
-                $this->httpHeaders[$key] = $value;
+            $name = $this->normaliseHeaderName($key);
+
+            if (strpos(strtoupper((string) $key), 'HTTP_') === 0 || isset($uaHeaders[$name])) {
+                $this->httpHeaders['HTTP_'.$name] = $this->normaliseHeaderValue($value);
             }
         }
+    }
+
+    /**
+     * Reduce a header name to its canonical form - uppercased, underscore
+     * separated, with any SAPI 'HTTP_' prefix removed.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function normaliseHeaderName($key)
+    {
+        $key = str_replace('-', '_', strtoupper((string) $key));
+
+        return strpos($key, 'HTTP_') === 0 ? substr($key, 5) : $key;
+    }
+
+    /**
+     * Flatten a header value. PSR-7 and HttpFoundation both expose values as
+     * an array of strings, where the SAPI gives a single pre-joined string.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function normaliseHeaderValue($value)
+    {
+        return is_array($value) ? implode(', ', $value) : (string) $value;
     }
 
     /**

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -127,6 +127,91 @@ final class UserAgentTest extends TestCase
         $this->assertTrue($cd->isCrawler());
     }
 
+    public function test_psr7_style_header_names()
+    {
+        // ServerRequestInterface::getHeaders() returns real header names with
+        // an array of strings for each value.
+        $cd = new CrawlerDetect([
+            'Host' => ['www.test.com'],
+            'User-Agent' => ['Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'],
+        ]);
+
+        $this->assertTrue($cd->isCrawler());
+    }
+
+    public function test_lowercase_dashed_header_names()
+    {
+        // HttpFoundation's HeaderBag::all() lowercases the names it returns.
+        $cd = new CrawlerDetect([
+            'user-agent' => ['Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'],
+        ]);
+
+        $this->assertTrue($cd->isCrawler());
+    }
+
+    public function test_scalar_header_values_are_accepted()
+    {
+        // Swoole and most Lambda event shapes give a plain string per header.
+        $cd = new CrawlerDetect([
+            'user-agent' => 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+        ]);
+
+        $this->assertTrue($cd->isCrawler());
+    }
+
+    public function test_from_header_is_honoured_from_a_non_sapi_source()
+    {
+        // Googlebot sometimes sends a genuine browser UA and identifies itself
+        // in the From header instead. The UA alone is not a match.
+        $headers = [
+            'From' => ['googlebot(at)googlebot.com'],
+            'User-Agent' => ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36'],
+        ];
+
+        $cd = new CrawlerDetect($headers);
+
+        $this->assertTrue($cd->isCrawler());
+        $this->assertFalse($cd->isCrawler($headers['User-Agent'][0]));
+    }
+
+    public function test_sec_ch_ua_header_is_honoured_from_a_non_sapi_source()
+    {
+        $cd = new CrawlerDetect([
+            'Sec-CH-UA' => ['"HeadlessChrome";v="129", "Not=A?Brand";v="8", "Chromium";v="129"'],
+        ]);
+
+        $this->assertTrue($cd->isCrawler());
+    }
+
+    public function test_mixed_case_sapi_header_names()
+    {
+        $cd = new CrawlerDetect([
+            'Http_User_Agent' => 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+        ]);
+
+        $this->assertTrue($cd->isCrawler());
+    }
+
+    public function test_non_header_server_vars_are_ignored()
+    {
+        // A URL can legitimately carry a crawler name, so these _SERVER vars
+        // must never be scanned even though their values would match.
+        $cd = new CrawlerDetect([
+            'REQUEST_URI' => '/?utm_source=bingbot',
+            'QUERY_STRING' => 'utm_source=bingbot',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36',
+        ]);
+
+        $this->assertFalse($cd->isCrawler());
+    }
+
+    public function test_ua_http_headers_retain_their_sapi_prefix()
+    {
+        // Public API - callers rely on these names, so they must not change.
+        $this->assertContains('HTTP_USER_AGENT', $this->crawlerDetect->getUaHttpHeaders());
+        $this->assertContains('HTTP_FROM', $this->crawlerDetect->getUaHttpHeaders());
+    }
+
     public function test_matches_does_not_persist_across_multiple_calls()
     {
         $this->crawlerDetect->isCrawler('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)');

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -205,6 +205,20 @@ final class UserAgentTest extends TestCase
         $this->assertFalse($cd->isCrawler());
     }
 
+    public function test_http_prefixed_real_header_names_are_not_treated_as_sapi_keys()
+    {
+        // 'Http-User-Agent' is a custom header, not the User-Agent header, so
+        // its value must never be read as one. Only an underscore-separated
+        // SAPI key carries the prefix we strip.
+        $cd = new CrawlerDetect([
+            'Http-User-Agent' => ['Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'],
+            'Http-From' => ['googlebot(at)googlebot.com'],
+            'User-Agent' => ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36'],
+        ]);
+
+        $this->assertFalse($cd->isCrawler());
+    }
+
     public function test_ua_http_headers_retain_their_sapi_prefix()
     {
         // Public API - callers rely on these names, so they must not change.


### PR DESCRIPTION
## The problem

`setHttpHeaders()` filtered incoming keys on the `HTTP_` prefix, so it only understood the `_SERVER`-style names PHP's SAPI produces. Headers arriving from anywhere else carry their real names, get dropped by that filter, and leave the user agent `null`.

That means the idiomatic integration for a PSR-7 framework silently classified **every** request as human. Verified against `master` before this change:

```php
$cd = new CrawlerDetect($request->getHeaders());
$cd->isCrawler();      // false — for a self-identifying bingbot
$cd->getUserAgent();   // NULL
```

No exception, no warning, not even an `Array to string conversion` notice — the prefix filter discards the keys before their values are ever read, so `isCrawler()` exits down the empty-string path.

The failure mode is what makes this worth fixing. A developer wires up the obvious call, tests it in a browser, gets a correct `false`, and ships. Crawler traffic is then indistinguishable from human traffic, and if CrawlerDetect is gating a rate limiter, Googlebot starts collecting 429s. That surfaces weeks later in Search Console rather than as any error in the application.

### A second, quieter loss

Callers who worked around this with `isCrawler($request->getHeaderLine('User-Agent'))` get the `User-Agent` checked, but silently lose the rest of the chain in `Fixtures\Headers` — 1 of 10 signals. That includes `From` and `Sec-CH-UA`, the two headers that exist precisely to catch crawlers sending a genuine browser `User-Agent`. Googlebot's documented habit of doing exactly that is unreachable from a PSR-7 source today:

| Same request, four ways | Before | After |
| --- | --- | --- |
| `new CrawlerDetect($request->getHeaders())` | `false` ✗ | `true` ✓ |
| `From` + genuine Chrome UA, PSR-7 shape | `false` ✗ | `true` ✓ |
| `isCrawler($request->getHeaderLine('User-Agent'))` | `false` | `false` (inherent — one header, one signal) |
| forged `['HTTP_FROM' => ..., 'HTTP_USER_AGENT' => ...]` | `true` ✓ | `true` ✓ |

## The change

Header names are reduced to a canonical form — uppercased, underscore separated, `HTTP_` prefix stripped — then stored back under `HTTP_`. `HTTP_USER_AGENT`, `User-Agent` and `user-agent` all land on the same key, which is the key `Fixtures\Headers` already lists, so `setUserAgent()` needs no change at all.

Values are also flattened, because `ServerRequestInterface::getHeaders()` and `HeaderBag::all()` both return `array<string, string[]>` where the SAPI gives a pre-joined string. Without that, the naive integration stringifies to `"Array"` — which matches no pattern, so it too fails closed.

The round-trip is lossless for every entry in the fixture:

| Fixture name | Real header | Canonical form |
| --- | --- | --- |
| `HTTP_X_OPERAMINI_PHONE_UA` | `X-OperaMini-Phone-UA` | `X_OPERAMINI_PHONE_UA` |
| `HTTP_X_UCBROWSER_DEVICE_UA` | `X-UCBrowser-Device-UA` | `X_UCBROWSER_DEVICE_UA` |
| `HTTP_SEC_CH_UA` | `Sec-CH-UA` | `SEC_CH_UA` |
| `HTTP_DEVICE_STOCK_UA` | `Device-Stock-UA` | `DEVICE_STOCK_UA` |

## Why not PSR-7 support instead

Typehinting `ServerRequestInterface` would mean depending on an HTTP abstraction — URI, body streams, uploaded files, immutability semantics — to call `getHeaderLine()` once, and would cost the zero-dependency property. It also only helps one ecosystem. Normalising header names is dependency-free and fixes Swoole, HttpFoundation, RoadRunner and Lambda at the same time.

It also makes a PSR-15 middleware a few lines in a satellite package, with no knowledge of this library's internal key format — consistent with how the Laravel, Symfony and Yii2 integrations already live in their own repos.

## Backwards compatibility

Nothing public changes. `getUaHttpHeaders()` still returns prefixed names, `setUserAgent()` and `isCrawler()` are untouched, and `$this->httpHeaders` keeps its `HTTP_` key shape for any subclass reaching into it. Purely additive, so a minor release.

**One accepted edge case, flagged for review:** a bare `$_SERVER['FROM']` or `$_SERVER['USER_AGENT']` — inherited as an environment variable rather than a real header — will now be read where before it was ignored. To change an outcome its value would also have to match a crawler pattern.

The tighter alternative is to require a dash in the original key, but that breaks `From`, the one single-word header in the fixture and also the most valuable Googlebot signal. I took the narrow env-var risk over losing `From`; happy to flip it if you'd rather.

## Who this does not affect

Worth stating plainly: **classic Apache/nginx with mod_php or FPM, using the no-argument constructor, sees no behavioural change** — likely still most installs. This is a correctness fix for PSR-7 frameworks, async workers and serverless runtimes, not a headline feature.

## Tests

Eight new cases in `UserAgentTest.php`: PSR-7 shape with array values, lowercase dashed names, scalar values, `From` honoured from a non-SAPI source (asserting the UA alone does *not* match), `Sec-CH-UA` from a non-SAPI source, mixed-case SAPI names, a guard that non-header `_SERVER` vars such as `REQUEST_URI` are still excluded even when their values would match, and a guard that `getUaHttpHeaders()` keeps its prefixed names.

Full suite green — 27 tests, 170,870 assertions. PHPStan level 5 at the 7.2 floor reports no errors.
